### PR TITLE
Adding GitLab Groups Resources to CICD

### DIFF
--- a/GitLab-Groups-Group/cleanup.sh
+++ b/GitLab-Groups-Group/cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+#
+# Clean up any prerequisites created in setup.sh
+

--- a/GitLab-Groups-Group/example_inputs/inputs_1_create.json
+++ b/GitLab-Groups-Group/example_inputs/inputs_1_create.json
@@ -1,5 +1,5 @@
 {
-    "ParentId": <GROUP_ID>,
+    "ParentId": GITLAB_PARENT_GROUP_ID,
     "Name": "my-sample-group",
     "Path": "path-to-sample-group"
 }

--- a/GitLab-Groups-Group/resource-role-prod.yaml
+++ b/GitLab-Groups-Group/resource-role-prod.yaml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  This CloudFormation template creates a role assumed by CloudFormation
+  during CRUDL operations to mutate resources on behalf of the customer.
+
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      MaxSessionDuration: 8400
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: resources.cloudformation.amazonaws.com
+            Action: sts:AssumeRole
+      Path: "/"
+      Policies:
+        - PolicyName: ResourceTypePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Deny
+                Action:
+                - "*"
+                Resource: "*"
+Outputs:
+  ExecutionRoleArn:
+    Value:
+      Fn::GetAtt: ExecutionRole.Arn

--- a/GitLab-Groups-Group/setup.sh
+++ b/GitLab-Groups-Group/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Set up any prerequisites needed for cfn test
+#
+mkdir -p inputs
+cat example_inputs/inputs_1_create.json | sed "s/GITLAB_PARENT_GROUP_ID/${GITLAB_PARENT_GROUP_ID}/g"  > inputs/inputs_1_create.json
+cat test/integ-template.yml | sed "s/GITLAB_PARENT_GROUP_ID/${GITLAB_PARENT_GROUP_ID}/g"  > test/integ.yml
+

--- a/GitLab-Groups-Group/test/integ-template.yml
+++ b/GitLab-Groups-Group/test/integ-template.yml
@@ -1,0 +1,7 @@
+Resources:
+  MySampleGroup:
+    Type: GitLab::Groups::Group
+    Properties:
+      ParentId: GITLAB_PARENT_GROUP_ID
+      Name: my-sample-group
+      Path: path-to-sample-group

--- a/GitLab-Groups-GroupAccessToGroup/cleanup.sh
+++ b/GitLab-Groups-GroupAccessToGroup/cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+#
+# Clean up any prerequisites created in setup.sh
+

--- a/GitLab-Groups-GroupAccessToGroup/example_inputs/inputs_1_create.json
+++ b/GitLab-Groups-GroupAccessToGroup/example_inputs/inputs_1_create.json
@@ -1,0 +1,5 @@
+{
+    "SharedGroupId": GITLAB_SHARED_GROUP_ID,
+    "SharedWithGroupId": GITLAB_GROUP_ID,
+    "AccessLevel": "Guest"
+}

--- a/GitLab-Groups-GroupAccessToGroup/inputs/inputs_1_create.json
+++ b/GitLab-Groups-GroupAccessToGroup/inputs/inputs_1_create.json
@@ -1,5 +1,0 @@
-{
-    "SharedGroupId": <FIRST_GROUP_ID>,
-    "SharedWithGroupId": <SECOND_GROUP_ID>,
-    "AccessLevel": "Guest"
-}

--- a/GitLab-Groups-GroupAccessToGroup/resource-role-prod.yaml
+++ b/GitLab-Groups-GroupAccessToGroup/resource-role-prod.yaml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  This CloudFormation template creates a role assumed by CloudFormation
+  during CRUDL operations to mutate resources on behalf of the customer.
+
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      MaxSessionDuration: 8400
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: resources.cloudformation.amazonaws.com
+            Action: sts:AssumeRole
+      Path: "/"
+      Policies:
+        - PolicyName: ResourceTypePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Deny
+                Action:
+                - "*"
+                Resource: "*"
+Outputs:
+  ExecutionRoleArn:
+    Value:
+      Fn::GetAtt: ExecutionRole.Arn

--- a/GitLab-Groups-GroupAccessToGroup/setup.sh
+++ b/GitLab-Groups-GroupAccessToGroup/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Set up any prerequisites needed for cfn test
+#
+mkdir -p inputs
+cat example_inputs/inputs_1_create.json | sed "s/GITLAB_SHARED_GROUP_ID/${GITLAB_SHARED_GROUP_ID}/g" | sed "s/GITLAB_GROUP_ID/${GITLAB_GROUP_ID}/g" > inputs/inputs_1_create.json
+cat test/integ-template.yml | sed "s/GITLAB_SHARED_GROUP_ID/${GITLAB_SHARED_GROUP_ID}/g" | sed "s/GITLAB_GROUP_ID/${GITLAB_GROUP_ID}/g" > test/integ.yml
+

--- a/GitLab-Groups-GroupAccessToGroup/test/integ-template.yml
+++ b/GitLab-Groups-GroupAccessToGroup/test/integ-template.yml
@@ -1,0 +1,7 @@
+Resources:
+  MyUserJoiningAGroup:
+    Type: GitLab::Groups::GroupAccessToGroup
+    Properties:
+      SharedGroupId: GITLAB_SHARED_GROUP_ID
+      SharedWithGroupId: GITLAB_GROUP_ID
+      AccessLevel: Maintainer

--- a/GitLab-Groups-UserMemberOfGroup/cleanup.sh
+++ b/GitLab-Groups-UserMemberOfGroup/cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+#
+# Clean up any prerequisites created in setup.sh
+

--- a/GitLab-Groups-UserMemberOfGroup/example_inputs/inputs_1_create.json
+++ b/GitLab-Groups-UserMemberOfGroup/example_inputs/inputs_1_create.json
@@ -1,0 +1,6 @@
+{
+    "GroupId": GITLAB_PARENT_GROUP_ID,
+    "UserId": GITLAB_SHARED_USER_ID,
+    "Username": "GITLAB_SHARED_USER_NAME",
+    "AccessLevel": "Guest"
+}

--- a/GitLab-Groups-UserMemberOfGroup/example_inputs/inputs_1_update.json
+++ b/GitLab-Groups-UserMemberOfGroup/example_inputs/inputs_1_update.json
@@ -1,0 +1,6 @@
+{
+    "GroupId": GITLAB_PARENT_GROUP_ID,
+    "UserId": GITLAB_SHARED_USER_ID,
+    "Username": "GITLAB_SHARED_USER_NAME",
+    "AccessLevel": "Developer"
+}

--- a/GitLab-Groups-UserMemberOfGroup/inputs/inputs_1_create.json
+++ b/GitLab-Groups-UserMemberOfGroup/inputs/inputs_1_create.json
@@ -1,6 +1,0 @@
-{
-    "GroupId": <FIRST_GROUP_ID>,
-    "UserId": <USER_ID>,
-    "Username": "<USERNAME>",
-    "AccessLevel": "Guest"
-}

--- a/GitLab-Groups-UserMemberOfGroup/inputs/inputs_1_update.json
+++ b/GitLab-Groups-UserMemberOfGroup/inputs/inputs_1_update.json
@@ -1,6 +1,0 @@
-{
-    "GroupId": <FIRST_GROUP_ID>,
-    "UserId": <USER_ID>,
-    "Username": "<USERNAME>",
-    "AccessLevel": "Developer"
-}

--- a/GitLab-Groups-UserMemberOfGroup/resource-role-prod.yaml
+++ b/GitLab-Groups-UserMemberOfGroup/resource-role-prod.yaml
@@ -1,0 +1,31 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  This CloudFormation template creates a role assumed by CloudFormation
+  during CRUDL operations to mutate resources on behalf of the customer.
+
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      MaxSessionDuration: 8400
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: resources.cloudformation.amazonaws.com
+            Action: sts:AssumeRole
+      Path: "/"
+      Policies:
+        - PolicyName: ResourceTypePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Deny
+                Action:
+                - "*"
+                Resource: "*"
+Outputs:
+  ExecutionRoleArn:
+    Value:
+      Fn::GetAtt: ExecutionRole.Arn

--- a/GitLab-Groups-UserMemberOfGroup/setup.sh
+++ b/GitLab-Groups-UserMemberOfGroup/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Set up any prerequisites needed for cfn test
+#
+mkdir -p inputs
+cat example_inputs/inputs_1_create.json | sed "s/GITLAB_PARENT_GROUP_ID/${GITLAB_PARENT_GROUP_ID}/g" | sed "s/GITLAB_SHARED_USER_ID/${GITLAB_SHARED_USER_ID}/g" | sed "s/GITLAB_SHARED_USER_NAME/${GITLAB_SHARED_USER_NAME}/g" > inputs/inputs_1_create.json
+cat example_inputs/inputs_1_update.json | sed "s/GITLAB_PARENT_GROUP_ID/${GITLAB_PARENT_GROUP_ID}/g" | sed "s/GITLAB_SHARED_USER_ID/${GITLAB_SHARED_USER_ID}/g" | sed "s/GITLAB_SHARED_USER_NAME/${GITLAB_SHARED_USER_NAME}/g" > inputs/inputs_1_update.json
+cat test/integ-template.yml | sed "s/GITLAB_PARENT_GROUP_ID/${GITLAB_PARENT_GROUP_ID}/g" | sed "s/GITLAB_SHARED_USER_ID/${GITLAB_SHARED_USER_ID}/g" | sed "s/GITLAB_SHARED_USER_NAME/${GITLAB_SHARED_USER_NAME}/g" > test/integ.yml
+

--- a/GitLab-Groups-UserMemberOfGroup/test/integ-template.yml
+++ b/GitLab-Groups-UserMemberOfGroup/test/integ-template.yml
@@ -1,0 +1,8 @@
+Resources:
+  MyUserJoiningAGroup:
+    Type: GitLab::Groups::UserMemberOfGroup
+    Properties:
+      GroupId: GITLAB_PARENT_GROUP_ID
+      UserId: GITLAB_SHARED_USER_ID
+      Username: GITLAB_SHARED_USER_NAME
+      AccessLevel: Guest


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Changes: 
Adding following GitLab resources to CICD 
GitLab-Groups-Group
GitLab-Groups-GroupAccessToGroup
GitLab-Groups-UserMemberOfGroup

Testing: 
Local testing is successful. 
<img width="663" alt="image" src="https://user-images.githubusercontent.com/118321621/221016959-1d41bf80-16d6-4ee8-9253-a7909f033f20.png">
